### PR TITLE
Fix PyInstaller dateparser packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ To run the bot on Windows without installing dependencies you can generate stand
    python build_exe.py
    ```
    A small window will open allowing one‑click creation of an exe for `mainnet` or `testnet`. It also works on systems without a command line. Move the files created under `dist/` together with `.env` to any folder you like.
+   The build script now calls PyInstaller with `--collect-all dateparser` so the
+   required time zone cache is packaged automatically. Without this option the
+   exe could fail with `dateparser_tz_cache.pkl` errors.
 
 ## Running Tests
 

--- a/build_exe.py
+++ b/build_exe.py
@@ -9,7 +9,17 @@ except Exception:  # pragma: no cover - optional on headless systems
     tk = None
     messagebox = None
 
-BASE_CMD = ["pyinstaller", "--onefile", "--clean", "--name"]
+# `dateparser` kitaplığının zaman dilimi verileri otomatik olarak paketlenmedik
+# için PyInstaller çalıştırırken bu verileri de dahil ediyoruz. Böylece exe
+# dosyası çalıştırıldığında `dateparser_tz_cache.pkl` hatası alınmıyor.
+BASE_CMD = [
+    "pyinstaller",
+    "--onefile",
+    "--clean",
+    "--collect-all",
+    "dateparser",
+    "--name",
+]
 
 
 def build(target: Path, name: str, status_cb=None) -> None:


### PR DESCRIPTION
## Summary
- package dateparser time zone data when building executables
- document the new build step in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883536203208328abfa09098add712e