### PR TITLE
Fix PyInstaller import issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ To run the bot on Windows without installing dependencies you can generate stand
    The build script now calls PyInstaller with `--collect-all dateparser` so the
    required time zone cache is packaged automatically. Without this option the
    exe could fail with `dateparser_tz_cache.pkl` errors.
+   Entry scripts now adjust `sys.path` when run directly so exes work without
+   import errors.
 
 ## Running Tests
 

--- a/bot/mainnet_bot.py
+++ b/bot/mainnet_bot.py
@@ -1,4 +1,10 @@
 import os
+import sys
+from pathlib import Path
+
+if __name__ == "__main__" and __package__ is None:
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    __package__ = "bot"
 
 # Bu dosya çalıştırıldığında ortam zorla mainnete ayarlanır
 os.environ["BINANCE_TESTNET"] = "false"

--- a/bot/testnet_bot.py
+++ b/bot/testnet_bot.py
@@ -1,4 +1,10 @@
 import os
+import sys
+from pathlib import Path
+
+if __name__ == "__main__" and __package__ is None:
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    __package__ = "bot"
 
 # Testnet botu çalışırken ortam değişkeni daima true olmalı
 os.environ["BINANCE_TESTNET"] = "true"


### PR DESCRIPTION
## Summary
- fix module path for direct execution
- note in README about entry scripts adjusting sys.path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'urllib3.contrib.appengine')*

------
https://chatgpt.com/codex/tasks/task_e_688355a45a508328a083710f91b90e46