### PR TITLE
PyInstaller exe hatasi duzeltildi

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,11 @@ To run the bot on Windows without installing dependencies you can generate stand
    required time zone cache is packaged automatically. Without this option the
    exe could fail with `dateparser_tz_cache.pkl` errors.
    Entry scripts now adjust `sys.path` when run directly so exes work without
-   import errors.
-   Frozen exe'ler için `sys.frozen` kontrolü eklenerek modül yolu otomatik
-   ayarlanır, böylece `bot` paketine ait içe aktarmalar hatasız çalışır.
+   import errors. Frozen exe'ler için `sys.frozen` kontrolü eklenerek ve
+   `sys._MEIPASS` dizini kullanılarak modül yolu otomatik ayarlanır, böylece
+   `bot` paketine ait içe aktarmalar hatasız çalışır. Böylece oluşturulan exe
+   çalıştırıldığında `ModuleNotFoundError: No module named 'bot'` hatası
+   görülmez.
 
 ## Running Tests
 

--- a/bot/mainnet_bot.py
+++ b/bot/mainnet_bot.py
@@ -3,7 +3,9 @@ import sys
 from pathlib import Path
 
 if getattr(sys, "frozen", False):
-    sys.path.append(str(Path(sys.executable).resolve().parent))
+    # PyInstaller tek dosya calistiginda kodlar _MEIPASS altina acilir.
+    base = Path(getattr(sys, "_MEIPASS", Path(sys.executable).resolve().parent))
+    sys.path.append(str(base))
     __package__ = "bot"
 elif __name__ == "__main__" and __package__ is None:
     sys.path.append(str(Path(__file__).resolve().parent.parent))

--- a/bot/testnet_bot.py
+++ b/bot/testnet_bot.py
@@ -3,7 +3,10 @@ import sys
 from pathlib import Path
 
 if getattr(sys, "frozen", False):
-    sys.path.append(str(Path(sys.executable).resolve().parent))
+    # PyInstaller tek dosya modunda kodlar gecici bir dizine cikarilir.
+    # `sys._MEIPASS` mevcutsa paketler buradan yuklenir.
+    base = Path(getattr(sys, "_MEIPASS", Path(sys.executable).resolve().parent))
+    sys.path.append(str(base))
     __package__ = "bot"
 elif __name__ == "__main__" and __package__ is None:
     sys.path.append(str(Path(__file__).resolve().parent.parent))


### PR DESCRIPTION
## Degisiklikler
- `testnet_bot.py` ve `mainnet_bot.py` basinda `_MEIPASS` kontrolu eklenerek PyInstaller tek dosya calistiginda modul yolu otomatik ayarlandi.
- README'de exe olusturma bolumu guncellenerek `ModuleNotFoundError` sorununa cozum aciklandi.

## Testler
- `pip install` ile gereken kutuphaneler kuruldu.
- `pytest -q` tum testlerin basariyla gectigi dogrulandi.

------
https://chatgpt.com/codex/tasks/task_e_68835d994dc48328ac82c3612da062b4