### PR TITLE
Fix PyInstaller module imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,14 @@ To run the bot on Windows without installing dependencies you can generate stand
    Entry scripts now adjust `sys.path` when run directly so exes work without
    import errors. Frozen exe'ler için `sys.frozen` kontrolü eklenerek ve
    `sys._MEIPASS` dizini kullanılarak modül yolu otomatik ayarlanır, böylece
-   `bot` paketine ait içe aktarmalar hatasız çalışır. Böylece oluşturulan exe
-   çalıştırıldığında `ModuleNotFoundError: No module named 'bot'` hatası
-   görülmez. Paket adının boş string olması da kontrol edilerek PyInstaller
-   ile oluşturulan exe'lerin her ortamda sorunsuz başlaması sağlandı.
+  `bot` paketine ait içe aktarmalar hatasız çalışır. Böylece oluşturulan exe
+  çalıştırıldığında `ModuleNotFoundError: No module named 'bot'` hatası
+  görülmez. Paket adının boş string olması da kontrol edilerek PyInstaller
+  ile oluşturulan exe'lerin her ortamda sorunsuz başlaması sağlandı.
+  Ayrıca PyInstaller derlemesinde tüm modüllerin paketlenebilmesi için
+  `mainnet_bot.py` ve `testnet_bot.py` dosyalarındaki içe aktarmalar mutlak
+  hale getirildi. Bu sayede `bot` paketindeki kodlar eksiksiz şekilde
+  arşive eklenir.
 
 ## Running Tests
 

--- a/bot/mainnet_bot.py
+++ b/bot/mainnet_bot.py
@@ -20,10 +20,10 @@ load_dotenv()
 import asyncio
 from binance import AsyncClient
 
-from .buy_bot import BuyBot
-from .sell_bot import SellBot, send_telegram, CHECK_INTERVAL
-from .telegram_listener import start_listener
-from .utils import log, setup_telegram_menu
+from bot.buy_bot import BuyBot
+from bot.sell_bot import SellBot, send_telegram, CHECK_INTERVAL
+from bot.telegram_listener import start_listener
+from bot.utils import log, setup_telegram_menu
 
 API_KEY = os.getenv("BINANCE_API_KEY")
 API_SECRET = os.getenv("BINANCE_API_SECRET")

--- a/bot/testnet_bot.py
+++ b/bot/testnet_bot.py
@@ -21,10 +21,10 @@ load_dotenv()
 import asyncio
 from binance import AsyncClient
 
-from .buy_bot import BuyBot
-from .sell_bot import SellBot, send_telegram, CHECK_INTERVAL
-from .telegram_listener import start_listener  # noqa: F401 - testler için içe aktarılıyor
-from .utils import log, setup_telegram_menu  # noqa: F401 - testler için içe aktarılıyor
+from bot.buy_bot import BuyBot
+from bot.sell_bot import SellBot, send_telegram, CHECK_INTERVAL
+from bot.telegram_listener import start_listener  # noqa: F401 - testler için içe aktarılıyor
+from bot.utils import log, setup_telegram_menu  # noqa: F401 - testler için içe aktarılıyor
 
 API_KEY = os.getenv("BINANCE_TESTNET_API_KEY")
 API_SECRET = os.getenv("BINANCE_TESTNET_API_SECRET")


### PR DESCRIPTION
## Summary
- use absolute imports in entry scripts so PyInstaller bundles modules
- document the need for absolute imports in README

## Testing
- `pytest -q`
- `pyinstaller --onefile --clean --collect-all dateparser --collect-submodules bot --name testnet_bot bot/testnet_bot.py` then run generated exe

------
https://chatgpt.com/codex/tasks/task_e_688361af9a508328ada28a96f7e427fb