### PR TITLE
Fix balances translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,21 @@ The `test_env_timezone_conversion` test verifies that the `LOCAL_TIMEZONE` setti
 
 Target levels are now divided into three steps from the fixed target up to the ATR target. Each target is printed when updated and a sale is executed if the price falls below that target. Once the highest target is passed and the price remains above it, a one minute volume analysis is repeated every cycle. If sell volume is higher than buy volume or the price drops back below the target, an automatic sale is made.
 
+### Çeviri Dosyaları
+
+`bot/messages/messages_[ar|fr|ja|ko|ru|zh].py` dosyalarındaki `/balances` mesajı tek satıra indirildi:
+
+```python
+'balances': 'Balance Symbols:\n{symbols}',
+```
+
+Her dosyanın sorunsuz içe aktarılabildiğini doğrulamak için aşağıdaki komut kullanılabilir:
+
+```bash
+python -m bot.messages.messages_fr
+```
+Benzer şekilde diğer diller de aynı komutla kontrol edilebilir.
+
 ## Support
 
 For donations our USDT address is: `THz1ssvnpVcmt9Kk24x4wD5XCMZBtnubnE`

--- a/bot/messages/messages_ar.py
+++ b/bot/messages/messages_ar.py
@@ -6,8 +6,7 @@ MESSAGES = {
     'report_unavailable': 'Report not available now',
     'no_report': 'No report yet',
     'report_header': 'End of Day Report:\n{msg}',
-    'balances': 'Balance Symbols:
-{symbols}',
+    'balances': 'Balance Symbols:\n{symbols}',
     'no_balance_symbols': 'No balance symbols',
     'no_tracked_symbols': 'No tracked symbols',
     'sell_unavailable': 'Sell not available now',

--- a/bot/messages/messages_fr.py
+++ b/bot/messages/messages_fr.py
@@ -6,8 +6,7 @@ MESSAGES = {
     'report_unavailable': 'Report not available now',
     'no_report': 'No report yet',
     'report_header': 'End of Day Report:\n{msg}',
-    'balances': 'Balance Symbols:
-{symbols}',
+    'balances': 'Balance Symbols:\n{symbols}',
     'no_balance_symbols': 'No balance symbols',
     'no_tracked_symbols': 'No tracked symbols',
     'sell_unavailable': 'Sell not available now',

--- a/bot/messages/messages_ja.py
+++ b/bot/messages/messages_ja.py
@@ -6,8 +6,7 @@ MESSAGES = {
     'report_unavailable': 'Report not available now',
     'no_report': 'No report yet',
     'report_header': 'End of Day Report:\n{msg}',
-    'balances': 'Balance Symbols:
-{symbols}',
+    'balances': 'Balance Symbols:\n{symbols}',
     'no_balance_symbols': 'No balance symbols',
     'no_tracked_symbols': 'No tracked symbols',
     'sell_unavailable': 'Sell not available now',

--- a/bot/messages/messages_ko.py
+++ b/bot/messages/messages_ko.py
@@ -6,8 +6,7 @@ MESSAGES = {
     'report_unavailable': 'Report not available now',
     'no_report': 'No report yet',
     'report_header': 'End of Day Report:\n{msg}',
-    'balances': 'Balance Symbols:
-{symbols}',
+    'balances': 'Balance Symbols:\n{symbols}',
     'no_balance_symbols': 'No balance symbols',
     'no_tracked_symbols': 'No tracked symbols',
     'sell_unavailable': 'Sell not available now',

--- a/bot/messages/messages_ru.py
+++ b/bot/messages/messages_ru.py
@@ -6,8 +6,7 @@ MESSAGES = {
     'report_unavailable': 'Report not available now',
     'no_report': 'No report yet',
     'report_header': 'End of Day Report:\n{msg}',
-    'balances': 'Balance Symbols:
-{symbols}',
+    'balances': 'Balance Symbols:\n{symbols}',
     'no_balance_symbols': 'No balance symbols',
     'no_tracked_symbols': 'No tracked symbols',
     'sell_unavailable': 'Sell not available now',

--- a/bot/messages/messages_zh.py
+++ b/bot/messages/messages_zh.py
@@ -6,8 +6,7 @@ MESSAGES = {
     'report_unavailable': 'Report not available now',
     'no_report': 'No report yet',
     'report_header': 'End of Day Report:\n{msg}',
-    'balances': 'Balance Symbols:
-{symbols}',
+    'balances': 'Balance Symbols:\n{symbols}',
     'no_balance_symbols': 'No balance symbols',
     'no_tracked_symbols': 'No tracked symbols',
     'sell_unavailable': 'Sell not available now',


### PR DESCRIPTION
## Summary
- keep `/balances` message on one line for non-English translations
- document translation imports in README

## Testing
- `python -m bot.messages.messages_ar`
- `python -m bot.messages.messages_fr`
- `python -m bot.messages.messages_ja`
- `python -m bot.messages.messages_ko`
- `python -m bot.messages.messages_ru`
- `python -m bot.messages.messages_zh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68836692ef0883288fc4eb41eac7c259