### PR TITLE
Fix PyInstaller translation imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ To run the bot on Windows without installing dependencies you can generate stand
    py -3 build_exe.py
    ```
    A small window will open allowing one‑click creation of an exe for `mainnet` or `testnet`. Time zone cache data from `dateparser` is bundled automatically so the generated executables run without errors. Move the files created under `dist/` together with `.env` to any folder you like.
+   Translation modules are now imported statically so multilingual Telegram messages also work in the exe.
 
 ## Running Tests
 

--- a/bot/messages/__init__.py
+++ b/bot/messages/__init__.py
@@ -1,23 +1,39 @@
 import os
-from importlib import import_module
+
+# PyInstaller dinamik importlari tespit edemediginden
+# ceviri modullerini burada dogrudan dahil ediyoruz
+from . import (
+    messages_en,
+    messages_de,
+    messages_tr,
+    messages_fr,
+    messages_ar,
+    messages_zh,
+    messages_ru,
+    messages_ja,
+    messages_ko,
+)
 
 LANG_MAP = {
-    'en': 'messages_en',
-    'de': 'messages_de',
-    'tr': 'messages_tr',
-    'fr': 'messages_fr',
-    'ar': 'messages_ar',
-    'zh': 'messages_zh',
-    'ru': 'messages_ru',
-    'ja': 'messages_ja',
-    'ko': 'messages_ko',
+    'en': messages_en,
+    'de': messages_de,
+    'tr': messages_tr,
+    'fr': messages_fr,
+    'ar': messages_ar,
+    'zh': messages_zh,
+    'ru': messages_ru,
+    'ja': messages_ja,
+    'ko': messages_ko,
 }
 
 _cache = {}
 
+
 def _load(lang: str):
     if lang not in _cache:
-        mod = import_module(f'.{LANG_MAP.get(lang, "messages_en")}', package=__name__)
+        mod = LANG_MAP.get(lang)
+        if mod is None:
+            mod = messages_en
         _cache[lang] = mod.MESSAGES
     return _cache[lang]
 

--- a/bot/messages/messages_ar.py
+++ b/bot/messages/messages_ar.py
@@ -6,8 +6,7 @@ MESSAGES = {
     'report_unavailable': 'Report not available now',
     'no_report': 'No report yet',
     'report_header': 'End of Day Report:\n{msg}',
-    'balances': 'Balance Symbols:
-{symbols}',
+    'balances': 'Balance Symbols:\n{symbols}',
     'no_balance_symbols': 'No balance symbols',
     'no_tracked_symbols': 'No tracked symbols',
     'sell_unavailable': 'Sell not available now',

--- a/bot/messages/messages_fr.py
+++ b/bot/messages/messages_fr.py
@@ -6,8 +6,7 @@ MESSAGES = {
     'report_unavailable': 'Report not available now',
     'no_report': 'No report yet',
     'report_header': 'End of Day Report:\n{msg}',
-    'balances': 'Balance Symbols:
-{symbols}',
+    'balances': 'Balance Symbols:\n{symbols}',
     'no_balance_symbols': 'No balance symbols',
     'no_tracked_symbols': 'No tracked symbols',
     'sell_unavailable': 'Sell not available now',

--- a/bot/messages/messages_ja.py
+++ b/bot/messages/messages_ja.py
@@ -6,8 +6,7 @@ MESSAGES = {
     'report_unavailable': 'Report not available now',
     'no_report': 'No report yet',
     'report_header': 'End of Day Report:\n{msg}',
-    'balances': 'Balance Symbols:
-{symbols}',
+    'balances': 'Balance Symbols:\n{symbols}',
     'no_balance_symbols': 'No balance symbols',
     'no_tracked_symbols': 'No tracked symbols',
     'sell_unavailable': 'Sell not available now',

--- a/bot/messages/messages_ko.py
+++ b/bot/messages/messages_ko.py
@@ -6,8 +6,7 @@ MESSAGES = {
     'report_unavailable': 'Report not available now',
     'no_report': 'No report yet',
     'report_header': 'End of Day Report:\n{msg}',
-    'balances': 'Balance Symbols:
-{symbols}',
+    'balances': 'Balance Symbols:\n{symbols}',
     'no_balance_symbols': 'No balance symbols',
     'no_tracked_symbols': 'No tracked symbols',
     'sell_unavailable': 'Sell not available now',

--- a/bot/messages/messages_ru.py
+++ b/bot/messages/messages_ru.py
@@ -6,8 +6,7 @@ MESSAGES = {
     'report_unavailable': 'Report not available now',
     'no_report': 'No report yet',
     'report_header': 'End of Day Report:\n{msg}',
-    'balances': 'Balance Symbols:
-{symbols}',
+    'balances': 'Balance Symbols:\n{symbols}',
     'no_balance_symbols': 'No balance symbols',
     'no_tracked_symbols': 'No tracked symbols',
     'sell_unavailable': 'Sell not available now',

--- a/bot/messages/messages_zh.py
+++ b/bot/messages/messages_zh.py
@@ -6,8 +6,7 @@ MESSAGES = {
     'report_unavailable': 'Report not available now',
     'no_report': 'No report yet',
     'report_header': 'End of Day Report:\n{msg}',
-    'balances': 'Balance Symbols:
-{symbols}',
+    'balances': 'Balance Symbols:\n{symbols}',
     'no_balance_symbols': 'No balance symbols',
     'no_tracked_symbols': 'No tracked symbols',
     'sell_unavailable': 'Sell not available now',


### PR DESCRIPTION
## Summary
- statically import translation modules so PyInstaller bundles them
- fix newline issues in translation files
- mention static imports in README

## Testing
- `pip install -r /tmp/req.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868be991c48328bf55d204a5d4e93e