### PR TITLE
Fix target reset bug and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A Python-based bot that monitors your Binance account and automatically sells wh
 - Recently sold symbols are also remembered and skipped for two hours.
 - Symbols skipped because of a recent buy are removed from the volume list until it refreshes.
 - Target prices are printed whenever updated and instantaneous targets are shown on price changes.
+- Targets update also reset the peak price so sales only happen after the new target is surpassed.
 - If the price drops back below any target level it is automatically sold.
 - When the highest target is passed and the price stays above it, a one minute volume analysis is repeated every cycle; if sell volume exceeds buy volume or the price dips back below the target an automatic sale is triggered.
 - Prices are monitored live via a websocket so sell decisions are applied without delay.
@@ -196,6 +197,7 @@ pytest -q
 The `test_env_timezone_conversion` test verifies that the `LOCAL_TIMEZONE` setting works correctly. The bot now reports your total balance at the end of each day at UTC‑0 via Telegram. These reports are stored in the `balances.db` SQLite file so that the `/report` command can show previous days after a restart. When no suitable symbol is found on the buy side a new strategy checking for SMA‑7 break and SMA‑7 < SMA‑25 is used. `build_exe.py` now provides a simple interface for generating an exe with one click.
 
 Target levels are now divided into three steps from the fixed target up to the ATR target. Each target is printed when updated and a sale is executed if the price falls below that target. Once the highest target is passed and the price remains above it, a one minute volume analysis is repeated every cycle. If sell volume is higher than buy volume or the price drops back below the target, an automatic sale is made.
+If target levels change while the price is below them, the previous high no longer triggers a sale until the new target is exceeded.
 
 
 ## Planned Features

--- a/bot/sell_bot.py
+++ b/bot/sell_bot.py
@@ -798,6 +798,9 @@ class SellBot:
         if target_str != pos.targets_str:
             log(f"{symbol} hedef fiyatlar güncellendi: {target_str}")
             pos.targets_str = target_str
+            pos.passed_steps.clear()
+            pos.hit_top_target = False
+            pos.peak = last_price
         profit_ratio = (last_price - base_price) / base_price if base_price else 0
         extreme_step = steps[-1]
         if profit_ratio >= extreme_step * 5:

--- a/tests/test_target_reset.py
+++ b/tests/test_target_reset.py
@@ -1,0 +1,38 @@
+import asyncio
+import bot.sell_bot as bot_module
+from bot.sell_bot import FifoTracker, Position
+
+
+class DummyClient:
+    async def get_recent_trades(self, symbol, limit=60):
+        return []
+
+    async def get_symbol_ticker(self, symbol):
+        return {"price": "3.18"}
+
+
+async def fake_open(self, symbol):
+    return 3.25
+
+
+async def fake_vol(*_args, **_kwargs):
+    return 0.1
+
+
+def test_targets_reset_peak(monkeypatch):
+    monkeypatch.setattr(bot_module.SellBot, "get_last_open_price", fake_open)
+    monkeypatch.setattr(bot_module.SellBot, "get_volatility", fake_vol)
+    bot_module.FEE_BUY = 0.0
+    bot_module.FEE_SELL = 0.0
+    bot_module.MIN_PROFIT = 0.0
+    bot_module.TARGET_STEPS = 1
+    watcher = bot_module.SellBot(DummyClient())
+    tracker = FifoTracker()
+    tracker.add_trade(1, 3.0)
+    pos = Position(tracker, 0.0, 0.0)
+    pos.peak = 3.3
+    watcher.positions["CAKEUSDT"] = pos
+    watcher.btc_above_sma7 = True
+    decision = asyncio.run(watcher.should_sell("CAKEUSDT", 3.18, 3.0))
+    assert decision is False
+    assert watcher.positions["CAKEUSDT"].peak == 3.18

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -437,8 +437,13 @@ def test_sell_when_step_lost(monkeypatch):
 
     monkeypatch.setattr(bot_module.SellBot, "get_volatility", fake_vol)
     watcher.btc_above_sma7 = True
+    # Hedef güncellendiğinde fiyat hedef üzerine çıkmadığı için satış yapmaz
     decision = asyncio.run(watcher.should_sell("BTCUSDT", 105.0, 100.0))
-    assert decision is True
+    assert decision is False
+    # Fiyat hedef geçildikten sonra altına düşerse satış yapar
+    pos.peak = 115.0
+    decision2 = asyncio.run(watcher.should_sell("BTCUSDT", 105.0, 100.0))
+    assert decision2 is True
 
 
 def test_sell_without_volume_when_profit_five_times(monkeypatch):


### PR DESCRIPTION
## Summary
- prevent selling if new targets haven't been passed yet
- reset peak when targets update
- adjust existing step-loss test and add new test
- document target reset logic in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68871512e1b883289866cb45391cbdaa