### PR TITLE
Add TELEGRAM_ENABLED option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ TESTNET_INITIAL_USDT=5000
 TELEGRAM_TOKEN=
 TELEGRAM_CHAT_ID=
 TELEGRAM_LANG=en
+TELEGRAM_ENABLED=true
 
 # ==============================
 # Bot Parameters

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A Python-based bot that monitors your Binance account and automatically sells wh
 The main variables in `.env` are:
 - `BINANCE_API_KEY` and `BINANCE_API_SECRET`
 - `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID`
+- `TELEGRAM_ENABLED` disables all Telegram features when set to `false`
 - `FEE_BUY_PERCENT`, `FEE_SELL_PERCENT`, `MIN_PROFIT_PERCENT`
 - `BINANCE_TESTNET` enables testnet mode.
 - `USDT_USAGE_RATIO` defines the portion of USDT to use for each buy cycle.
@@ -78,6 +79,7 @@ The Telegram language is chosen with the `TELEGRAM_LANG` variable in `.env`. Sup
 
 ```bash
 TELEGRAM_LANG=en
+TELEGRAM_ENABLED=true
 ```
 
 ### Creating a Binance Testnet Account
@@ -148,6 +150,7 @@ Exit the virtual environment with:
 source deactivate
 ```
 These two files ignore the `BINANCE_TESTNET` value in `.env` and configure the required mode themselves. To test only the sell side on testnet enable `BINANCE_TESTNET=true` and run `python -m bot.sell_bot` again. Both bots report which network they are on and how many symbols are tracked via Telegram along with the IP address at startup. If the Telegram token is in use elsewhere the detected `Conflict` error prevents the chat bot from starting. All symbols in your balance are monitored even in testnet mode. Set `LOCAL_TIMEZONE` in `.env` to control log and console output times. For example `LOCAL_TIMEZONE=Europe/Istanbul` writes all logs in Turkish time. In testnet mode general notifications are no longer sent to Telegram; only buy operations and sales (if the buy price is not `0`) are reported. Other info is printed to the console. Important parts of notifications are **bold** and copyable fields such as IP or errors are wrapped in backticks. Trailing commas and spaces are cleaned up from all Telegram messages. Every message sent in testnet mode is prefixed with **TESTNET**. After an API error the next attempt waits 10 seconds. Sales of balances with a buy price of `0` are not announced via Telegram. The testnet bot no longer creates a Telegram menu and the chat bot is disabled; commands are active only in mainnet mode.
+Setting `TELEGRAM_ENABLED=false` disables all Telegram notifications and the chat bot regardless of other settings.
 
 ## Telegram Commands
 

--- a/bot/buy_bot.py
+++ b/bot/buy_bot.py
@@ -38,6 +38,7 @@ API_SECRET = (
 )
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
 CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
+TELEGRAM_ENABLED = os.getenv("TELEGRAM_ENABLED", "true").lower() == "true"
 MIN_PROFIT_PERCENT = float(os.getenv("MIN_PROFIT_PERCENT", "0.5"))
 MIN_PROFIT_RATIO = MIN_PROFIT_PERCENT / 100
 
@@ -70,6 +71,9 @@ def send_telegram(text: str, chat_id: Optional[str] = None, force: bool = False)
         if not force:
             log(text)
             return
+    if not TELEGRAM_ENABLED:
+        log(text)
+        return
     chat_id = chat_id or CHAT_ID
     if not TELEGRAM_TOKEN or not chat_id:
         log(text)

--- a/bot/mainnet_bot.py
+++ b/bot/mainnet_bot.py
@@ -13,6 +13,8 @@ from .buy_bot import BuyBot
 from .sell_bot import SellBot, send_telegram, CHECK_INTERVAL
 from .telegram_listener import start_listener
 
+TELEGRAM_ENABLED = os.getenv("TELEGRAM_ENABLED", "true").lower() == "true"
+
 
 API_KEY = os.getenv("BINANCE_API_KEY")
 API_SECRET = os.getenv("BINANCE_API_SECRET")
@@ -21,12 +23,13 @@ API_SECRET = os.getenv("BINANCE_API_SECRET")
 async def main():
     log("Mainnet botu baslatiliyor")
     token = os.getenv("TELEGRAM_TOKEN")
-    if token:
+    if token and TELEGRAM_ENABLED:
         setup_telegram_menu(token)
     client = await AsyncClient.create(API_KEY, API_SECRET)
     buy_bot = BuyBot(client)
     sell_bot = SellBot(client)
-    start_listener(asyncio.get_running_loop(), sell_bot, buy_bot)
+    if TELEGRAM_ENABLED:
+        start_listener(asyncio.get_running_loop(), sell_bot, buy_bot)
 
     await sell_bot.start()
     asyncio.create_task(buy_bot.start())

--- a/bot/sell_bot.py
+++ b/bot/sell_bot.py
@@ -36,6 +36,7 @@ API_SECRET = (
 )
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
 CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
+TELEGRAM_ENABLED = os.getenv("TELEGRAM_ENABLED", "true").lower() == "true"
 FEE_BUY = float(os.getenv("FEE_BUY_PERCENT", "0.1")) / 100
 FEE_SELL = float(os.getenv("FEE_SELL_PERCENT", "0.1")) / 100
 MIN_PROFIT = float(os.getenv("MIN_PROFIT_PERCENT", "0.5")) / 100
@@ -58,6 +59,9 @@ def send_telegram(text: str, chat_id: Optional[str] = None, force: bool = False)
         if not force:
             log(text)
             return
+    if not TELEGRAM_ENABLED:
+        log(text)
+        return
     chat_id = chat_id or CHAT_ID
     if not TELEGRAM_TOKEN or not chat_id:
         log(text)

--- a/bot/telegram_listener.py
+++ b/bot/telegram_listener.py
@@ -7,6 +7,8 @@ from .sell_bot import send_telegram
 from .utils import log
 from .messages import t
 
+TELEGRAM_ENABLED = os.getenv("TELEGRAM_ENABLED", "true").lower() == "true"
+
 
 def _format_position(symbol, position, price):
     avg = position.tracker.average_price()
@@ -32,6 +34,9 @@ def _authorized(chat_id: str) -> bool:
 
 def start_listener(loop: asyncio.AbstractEventLoop, sell_bot=None, buy_bot=None) -> None:
     """Telegram bot komutlarini dinle."""
+    if not TELEGRAM_ENABLED:
+        log("Telegram devre disi, listener baslatilmadi")
+        return
     token = os.getenv("TELEGRAM_TOKEN")
     if not token:
         log("TELEGRAM_TOKEN tanimsiz, listener baslatilmadi")

--- a/tests/test_buy_bot.py
+++ b/tests/test_buy_bot.py
@@ -786,6 +786,22 @@ def test_send_telegram_prefix(monkeypatch):
     assert messages and messages[0].startswith("TESTNET")
 
 
+def test_send_telegram_disabled(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_ENABLED", "false")
+    module = importlib.reload(buy_bot)
+    calls = []
+
+    def fake_post(url, json=None, timeout=10):
+        calls.append("sent")
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+    module.TELEGRAM_TOKEN = "T"
+    module.CHAT_ID = "C"
+    monkeypatch.setattr(module, "log", lambda m: calls.append(m))
+    module.send_telegram("deneme")
+    assert "sent" not in calls
+
+
 def test_start_message_once(monkeypatch):
     monkeypatch.setenv("BINANCE_TESTNET", "false")
     module = importlib.reload(buy_bot)

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -21,6 +21,18 @@ def test_start_listener_conflict(monkeypatch):
     assert any('baslatilamadi' in m for m in logs)
 
 
+def test_listener_disabled(monkeypatch):
+    logs = []
+    monkeypatch.setattr(listener, 'log', lambda m: logs.append(m))
+    monkeypatch.setenv('TELEGRAM_ENABLED', 'false')
+    loop = asyncio.new_event_loop()
+    try:
+        listener.start_listener(loop)
+    finally:
+        loop.close()
+    assert any('devre disi' in m for m in logs)
+
+
 def test_cmd_buy_handles_skip(monkeypatch):
     messages = []
 


### PR DESCRIPTION
## Summary
- allow Telegram features to be disabled via `TELEGRAM_ENABLED`
- document the new setting in the README and `.env.example`
- honour `TELEGRAM_ENABLED` in buy/sell bots, listener and mainnet bot
- test that Telegram is skipped when disabled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'telegram.vendor.ptb_urllib3.urllib3.packages.six.moves')*

------
https://chatgpt.com/codex/tasks/task_e_688717c6398c8328ad1e661f6db98d87