### PR TITLE
Takip kontrolü 55. dakikaya çekildi

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Python-based bot that monitors your Binance account and automatically sells wh
 - Timestamps are kept in **UTC‑0** on the backend and shown in your browser time zone.
 - Recently bought symbols are stored with a UTC timestamp and skipped for two hours.
 - Recently sold symbols are also remembered and skipped for two hours.
-- Her döngüde bakiye kontrolü yapılarak yeni alınan coinler otomatik olarak takibe eklenir ve mevcut pozisyonların ortalama maliyeti güncellenir.
+- Cüzdan bakiyesi her saatin **55. dakikasında** kontrol edilir; yeni alınan coinler takibe eklenir ve mevcut pozisyonların ortalama maliyeti güncellenir.
 - Symbols skipped because of a recent buy are removed from the volume list until it refreshes.
 - Target prices are printed whenever updated and instantaneous targets are shown on price changes.
 - When BTC is above the 7-period SMA on the 15-minute chart and the last closed candle opened higher than your average buy price, targets are calculated from that opening price.

--- a/bot/sell_bot.py
+++ b/bot/sell_bot.py
@@ -740,7 +740,9 @@ class SellBot:
             log("API hatası devam ediyor, kontrol atlandı")
             return
         await self.sync_time()
-        await self.check_new_balances()
+        now = datetime.now(timezone.utc)
+        if now.minute == 55:
+            await self.check_new_balances()
         if await self.is_btc_below_sma99():
             log("BTC SMA99 altinda, tum pozisyonlar satiliyor")
             await self.sell_all_positions()


### PR DESCRIPTION
## Özellikler
- `SellBot.check_positions` fonksiyonu cüzdan taramasını sadece her saatin 55. dakikasında çağırıyor.
- README'de bakiye kontrolünün yeni zamanlaması açıklandı.

## Testler
- `pytest -q` çalıştırıldı ve tüm testler (103) başarılı olarak sonuçlandı.

------
https://chatgpt.com/codex/tasks/task_e_6888aef3252483288ff7e088ea82dc0d